### PR TITLE
Make the type variable in `read*` functions visibly-applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.1
+
+- Allow the type of `read*` functions to be visibly applied (#24 by @postsolar)
+
 ## v4.0.0
 - Replace `bigints` dependency with `js-bigints` so that no more external npm dependency is needed (#11 by @sigma-andex)
 

--- a/src/Yoga/JSON.purs
+++ b/src/Yoga/JSON.purs
@@ -90,7 +90,7 @@ type E a = Either MultipleErrors a
 -- | Read a JSON string to a type `a` while returning a `MultipleErrors` if the
 -- | parsing failed.
 readJSON ∷
-  ∀ a.
+  ∀ @a.
   ReadForeign a ⇒
   String →
   E a
@@ -98,7 +98,7 @@ readJSON = runExcept <<< (readImpl <=< parseJSON)
 
 -- | Read a JSON string to a type `a` using `F a`. Useful with record types.
 readJSON' ∷
-  ∀ a.
+  ∀ @a.
   ReadForeign a ⇒
   String →
   F a
@@ -107,7 +107,7 @@ readJSON' = readImpl <=< parseJSON
 -- | Read a JSON string to a type `a` while returning `Nothing` if the parsing
 -- | failed.
 readJSON_ ∷
-  ∀ a.
+  ∀ @a.
   ReadForeign a ⇒
   String →
   Maybe a
@@ -147,14 +147,14 @@ write = writeImpl
 
 -- | Read a Foreign value to a type
 read ∷
-  ∀ a.
+  ∀ @a.
   ReadForeign a ⇒
   Foreign →
   E a
 read = runExcept <<< readImpl
 
 read' ∷
-  ∀ a.
+  ∀ @a.
   ReadForeign a ⇒
   Foreign →
   F a
@@ -162,7 +162,7 @@ read' = readImpl
 
 -- | Read a Foreign value to a type, as a Maybe of type
 read_ ∷
-  ∀ a.
+  ∀ @a.
   ReadForeign a ⇒
   Foreign →
   Maybe a


### PR DESCRIPTION
This would make syntax slightly more convenient for cases where the type of parsing result couldn't be infered.